### PR TITLE
recovery-flash:  add '-e' flag for bash

### DIFF
--- a/recovery-flash.sh
+++ b/recovery-flash.sh
@@ -1,4 +1,5 @@
-#/bin/bash
+#/bin/bash -e
+
 DEVICE=$1
 IMG_FOLDER=${PWD}
 


### PR DESCRIPTION
Per suggested by @axel on 96boards forum, the bash script should add
'-e' flag so the script can fail when error happens.

Signed-off-by: Leo Yan <leo.yan@linaro.org>