### PR TITLE
fix documentation / help text

### DIFF
--- a/README-flash-uefi.md
+++ b/README-flash-uefi.md
@@ -36,7 +36,7 @@ On the Hikey960
 
   ...Connect the usb-c otg to host system and make sure that shows up as ttyUSB1
 
-2. ``` sudo ./hikey960-efi-prebuilt.sh -h ```
+2. ``` sudo ./recovery-flash-uefi-prebuilt.sh -h ```
 
 3. Set switch 1 to on and 2 & 3 to off
 

--- a/recovery-flash-uefi-prebuilt.sh
+++ b/recovery-flash-uefi-prebuilt.sh
@@ -14,7 +14,7 @@ RELEASE=release
 DEVICE=/dev/ttyUSB1
 
 if [ $# -eq 0 ]; then
-	echo "Usage: hikey-efi-flash-image -h"
+	echo "Usage: $0 -h"
 	exit 0
 fi
 


### PR DESCRIPTION
doc was broken by myself in 9e191b8504b10829cc11569e31fe0739975f4b1e,
usage text was never correct